### PR TITLE
Use Jackson instead of jsonsimple

### DIFF
--- a/baka4j/build.gradle.kts
+++ b/baka4j/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 dependencies {
     // Json library
     implementation("org.json:json:20240303")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2")
 }
 
 // Force Java 21

--- a/baka4j/src/main/java/xyz/slosa/BakalariAPI.java
+++ b/baka4j/src/main/java/xyz/slosa/BakalariAPI.java
@@ -1,6 +1,8 @@
 package xyz.slosa;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONObject;
+import xyz.slosa.endpoints.http.impl.gdpr.GdprCommissionersRequest;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpGETRequest;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpPOSTRequest;
 import xyz.slosa.objects.BakaObject;
@@ -70,7 +72,11 @@ public class BakalariAPI {
                 logger.accept("Response: " + response.body());
             }
             // Deserialize the response body into the request object
-            httpRequest.fillData(httpRequest.deserialize(new JSONObject(response.body())));
+            try {
+                httpRequest.fillData(httpRequest.deserialize(response.body()));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
             return httpRequest; // Return the request
         }).exceptionally(ex -> {
             // Handle any exceptions that occurred during the request

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/absence/StudentAbsenceBakaRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/absence/StudentAbsenceBakaRequest.java
@@ -1,11 +1,13 @@
 package xyz.slosa.endpoints.http.impl.absence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpGETRequest;
 import xyz.slosa.objects.impl.absence.AbsenceData;
 import xyz.slosa.objects.impl.absence.AbsenceDataObject;
 import xyz.slosa.objects.impl.absence.SubjectAbsenceData;
+import xyz.slosa.objects.impl.gdpr.GdprCommissionersObject;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -19,7 +21,7 @@ import java.time.format.DateTimeFormatter;
  *
  * <p><b>Response Structure:</b></p>
  * <ul>
- *     <li><b>PercentageThreshold</b> - The threshold percentage for absence (e.g., 0.18)</li>
+ *     <li><b>PercentageThreshold</b> - The percentageThreshold percentage for absence (e.g., 0.18)</li>
  *     <li><b>Absences</b> - List of absence records for the student, including details for each day:</li>
  *     <ul>
  *         <li><b>Date</b> - The date of absence (e.g., "2020-02-30T00:00:00+01:00")</li>
@@ -108,5 +110,10 @@ public class StudentAbsenceBakaRequest extends AbstractBakaHttpGETRequest<Absenc
 
         // Create and return the AbsenceDataObject
         return new AbsenceDataObject(percentageThreshold, absenceData, subjectAbsenceData);
+    }
+
+    @Override
+    public AbsenceDataObject deserialize(String json) throws JsonProcessingException {
+        return getDeserializer().readValue(json, AbsenceDataObject.class);
     }
 }

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/events/StudentEventBakaRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/events/StudentEventBakaRequest.java
@@ -1,8 +1,10 @@
 package xyz.slosa.endpoints.http.impl.events;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpGETRequest;
+import xyz.slosa.objects.impl.absence.AbsenceDataObject;
 import xyz.slosa.objects.impl.event.EventData;
 import xyz.slosa.objects.impl.event.EventDetails;
 import xyz.slosa.objects.impl.event.EventDetailsObject;
@@ -72,6 +74,11 @@ public class StudentEventBakaRequest extends AbstractBakaHttpGETRequest<EventDet
         }
 
         return new EventDetailsObject(events);
+    }
+
+    @Override
+    public EventDetailsObject deserialize(String json) throws JsonProcessingException {
+        return getDeserializer().readValue(json, EventDetailsObject.class);
     }
 
     /**

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/gdpr/GdprCommissionersRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/gdpr/GdprCommissionersRequest.java
@@ -1,10 +1,13 @@
 package xyz.slosa.endpoints.http.impl.gdpr;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpGETRequest;
 import xyz.slosa.objects.impl.gdpr.GdprCommissioner;
 import xyz.slosa.objects.impl.gdpr.GdprCommissionersObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Handles the HTTP GET request for retrieving GDPR commissioners data from the API.
@@ -50,5 +53,10 @@ public class GdprCommissionersRequest extends AbstractBakaHttpGETRequest<GdprCom
         }
 
         return new GdprCommissionersObject(commissioners);
+    }
+
+    @Override
+    public GdprCommissionersObject deserialize(String json) throws JsonProcessingException {
+        return getDeserializer().readValue(json, GdprCommissionersObject.class);
     }
 }

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/login/LoginWithCredentialsBakaRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/login/LoginWithCredentialsBakaRequest.java
@@ -1,7 +1,10 @@
 package xyz.slosa.endpoints.http.impl.login;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpPOSTRequest;
+import xyz.slosa.objects.impl.absence.AbsenceDataObject;
 import xyz.slosa.objects.impl.login.LoginDataObject;
 
 import java.net.URLEncoder;
@@ -68,6 +71,12 @@ public class LoginWithCredentialsBakaRequest extends AbstractBakaHttpPOSTRequest
     @Override
     public LoginDataObject deserialize(final JSONObject jsonObject) {
         final String accessToken = jsonObject.optString("access_token"); // Main thing we want is the access token
+        return new LoginDataObject(login, password, accessToken);
+    }
+
+    @Override
+    public LoginDataObject deserialize(String json) throws JsonProcessingException {
+        final String accessToken = getDeserializer().readValue(json, JsonNode.class).get("access_token").asText();
         return new LoginDataObject(login, password, accessToken);
     }
 }

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/login/LoginWithRefreshTokenBakaRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/login/LoginWithRefreshTokenBakaRequest.java
@@ -1,5 +1,7 @@
 package xyz.slosa.endpoints.http.impl.login;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpPOSTRequest;
 import xyz.slosa.objects.impl.login.LoginDataObject;
@@ -65,6 +67,12 @@ public class LoginWithRefreshTokenBakaRequest extends AbstractBakaHttpPOSTReques
     public LoginDataObject deserialize(final JSONObject jsonObject) {
         final String accessToken = jsonObject.optString("access_token"); // Main thing we want is the access token
         // Since login is via refresh token, login and password fields are null
+        return new LoginDataObject(null, null, accessToken);
+    }
+
+    @Override
+    public LoginDataObject deserialize(String json) throws JsonProcessingException {
+        final String accessToken = getDeserializer().readValue(json, JsonNode.class).get("access_token").asText();
         return new LoginDataObject(null, null, accessToken);
     }
 }

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/marks/StudentMarksRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/marks/StudentMarksRequest.java
@@ -1,8 +1,11 @@
 package xyz.slosa.endpoints.http.impl.marks;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpGETRequest;
+import xyz.slosa.objects.impl.event.EventDetailsObject;
 import xyz.slosa.objects.impl.marks.Mark;
 import xyz.slosa.objects.impl.marks.MarksObject;
 import xyz.slosa.objects.impl.marks.Subject;
@@ -89,6 +92,11 @@ public class StudentMarksRequest extends AbstractBakaHttpGETRequest<MarksObject>
         }
 
         return new MarksObject(subjectMarksArray);
+    }
+
+    @Override
+    public MarksObject deserialize(String json) throws JsonProcessingException {
+        return getDeserializer().readValue(json, MarksObject.class);
     }
 }
 

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/marks/certificates/StudentCertificatesRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/marks/certificates/StudentCertificatesRequest.java
@@ -1,8 +1,10 @@
 package xyz.slosa.endpoints.http.impl.marks.certificates;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpGETRequest;
+import xyz.slosa.objects.impl.event.EventDetailsObject;
 import xyz.slosa.objects.impl.marks.Subject;
 import xyz.slosa.objects.impl.marks.certificates.CertificateTerm;
 import xyz.slosa.objects.impl.marks.certificates.CertificatesObject;
@@ -93,5 +95,10 @@ public class StudentCertificatesRequest extends AbstractBakaHttpGETRequest<Certi
         }
 
         return new CertificatesObject(certificateTerms);
+    }
+
+    @Override
+    public CertificatesObject deserialize(String json) throws JsonProcessingException {
+        return getDeserializer().readValue(json, CertificatesObject.class);
     }
 }

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/measures/PedagogicalMeasuresBakaRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/impl/measures/PedagogicalMeasuresBakaRequest.java
@@ -1,5 +1,6 @@
 package xyz.slosa.endpoints.http.impl.measures;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import xyz.slosa.endpoints.http.request.types.AbstractBakaHttpGETRequest;
@@ -56,5 +57,10 @@ public class PedagogicalMeasuresBakaRequest extends AbstractBakaHttpGETRequest<P
         }
 
         return new PedagogicalMeasuresObject(measures);
+    }
+
+    @Override
+    public PedagogicalMeasuresObject deserialize(String json) throws JsonProcessingException {
+        return getDeserializer().readValue(json, PedagogicalMeasuresObject.class);
     }
 }

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/request/AbstractBakaHttpRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/request/AbstractBakaHttpRequest.java
@@ -1,7 +1,15 @@
 package xyz.slosa.endpoints.http.request;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import org.json.JSONObject;
 import xyz.slosa.objects.BakaObject;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Abstract base class for handling HTTP requests to the Bakalari API.
@@ -29,7 +37,10 @@ public abstract class AbstractBakaHttpRequest<T extends BakaObject> {
      * @param jsonObject the JSON object containing the data to be deserialized
      * @return the deserialized object of type O
      */
+    @Deprecated
     public abstract T deserialize(final JSONObject jsonObject);
+    
+    public abstract T deserialize(final String json) throws JsonProcessingException;
 
     /**
      * Returns the deserialized object data, if it exists.
@@ -54,5 +65,13 @@ public abstract class AbstractBakaHttpRequest<T extends BakaObject> {
      */
     public String getEndpoint() {
         return endpoint;
+    }
+    
+    protected ObjectMapper getDeserializer() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule().addDeserializer(LocalDateTime.class,
+                new LocalDateTimeDeserializer(DateTimeFormatter.ISO_OFFSET_DATE_TIME)));
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+        return mapper;
     }
 }

--- a/baka4j/src/main/java/xyz/slosa/endpoints/http/request/types/AbstractBakaHttpGETRequest.java
+++ b/baka4j/src/main/java/xyz/slosa/endpoints/http/request/types/AbstractBakaHttpGETRequest.java
@@ -20,5 +20,4 @@ public abstract class AbstractBakaHttpGETRequest<T extends BakaObject> extends A
     public AbstractBakaHttpGETRequest(final String endpoint) {
         super(endpoint);
     }
-
 }

--- a/baka4j/src/main/java/xyz/slosa/objects/impl/absence/AbsenceData.java
+++ b/baka4j/src/main/java/xyz/slosa/objects/impl/absence/AbsenceData.java
@@ -2,7 +2,7 @@ package xyz.slosa.objects.impl.absence;
 
 import java.time.LocalDateTime;
 
-public record AbsenceData(LocalDateTime time,
+public record AbsenceData(LocalDateTime date,
                           int unsolved,
                           int ok,
                           int missed,

--- a/baka4j/src/main/java/xyz/slosa/objects/impl/absence/AbsenceDataObject.java
+++ b/baka4j/src/main/java/xyz/slosa/objects/impl/absence/AbsenceDataObject.java
@@ -2,7 +2,7 @@ package xyz.slosa.objects.impl.absence;
 
 import xyz.slosa.objects.BakaObject;
 
-public record AbsenceDataObject(float threshold,
-                                AbsenceData[] absenceData,
-                                SubjectAbsenceData[] subjectAbsences) implements BakaObject {
+public record AbsenceDataObject(float percentageThreshold,
+                                AbsenceData[] absences,
+                                SubjectAbsenceData[] absencesPerSubject) implements BakaObject {
 }

--- a/baka4j/src/main/java/xyz/slosa/objects/impl/absence/SubjectAbsenceData.java
+++ b/baka4j/src/main/java/xyz/slosa/objects/impl/absence/SubjectAbsenceData.java
@@ -2,11 +2,11 @@ package xyz.slosa.objects.impl.absence;
 
 import xyz.slosa.objects.BakaObject;
 
-public record SubjectAbsenceData(String name,
-                                 int lessonCount,
+public record SubjectAbsenceData(String subjectName,
+                                 int lessonsCount,
                                  int base,
                                  int late,
                                  int soon,
                                  int school,
-                                 int distantTeaching) implements BakaObject {
+                                 int distanceTeaching) implements BakaObject {
 }

--- a/baka4j/src/test/java/Main.java
+++ b/baka4j/src/test/java/Main.java
@@ -1,7 +1,6 @@
 import xyz.slosa.BakalariAPI;
 import xyz.slosa.endpoints.http.impl.absence.StudentAbsenceBakaRequest;
 import xyz.slosa.endpoints.http.impl.login.LoginWithCredentialsBakaRequest;
-import xyz.slosa.objects.impl.absence.AbsenceData;
 import xyz.slosa.objects.impl.absence.AbsenceDataObject;
 import xyz.slosa.objects.impl.absence.SubjectAbsenceData;
 import xyz.slosa.objects.impl.login.LoginDataObject;
@@ -19,11 +18,11 @@ public class Main {
 
         final AbsenceDataObject data = api.request(new StudentAbsenceBakaRequest(), token).join().getData();
 
-        final SubjectAbsenceData[] subjectAbsenceData = data.subjectAbsences();
+        final SubjectAbsenceData[] subjectAbsenceData = data.absencesPerSubject();
 
         for (SubjectAbsenceData subjectAbsenceData1 : subjectAbsenceData) {
-            System.out.println("name: " + subjectAbsenceData1.name());
-            System.out.println("lessons: " +subjectAbsenceData1.lessonCount() + " missed: " + subjectAbsenceData1.base());
+            System.out.println("name: " + subjectAbsenceData1.subjectName());
+            System.out.println("lessons: " +subjectAbsenceData1.lessonsCount() + " missed: " + subjectAbsenceData1.base());
             System.out.println("------------");
         }
     }


### PR DESCRIPTION
Starts using Jackson databind instead of org.json.
This assures easier deserialization.
This PR doesn't remove the json dependency.